### PR TITLE
feat: add POSIX compliant Serial export with "nt" os.name guard to root

### DIFF
--- a/src/samps/__init__.py
+++ b/src/samps/__init__.py
@@ -5,6 +5,17 @@
 
 # **************************************************************************************
 
+from os import name
+
+# If the operating system is Windows, raise an ImportError:
+if name == "nt":
+    raise ImportError(
+        "The samps package is not supported on Windows yet. "
+        "Please use a different operating system."
+    )
+
+# **************************************************************************************
+
 from .baudrate import BAUDRATE_LOOKUP_FLAGS, BAUDRATES, BaudrateType
 from .common import SerialCommonInterface, SerialCommonInterfaceParameters
 from .errors import (
@@ -12,6 +23,10 @@ from .errors import (
     SerialTimeoutError,
     SerialWriteError,
 )
+
+# If the operating system is POSIX compliant, import the Serial class from the common module:
+if name == "posix":
+    from .common import SerialCommonInterface as Serial
 
 # **************************************************************************************
 
@@ -29,6 +44,7 @@ __all__: list[str] = [
     "BAUDRATE_LOOKUP_FLAGS",
     "BAUDRATES",
     "BaudrateType",
+    "Serial",
     "SerialCommonInterface",
     "SerialCommonInterfaceParameters",
     "SerialReadError",


### PR DESCRIPTION
feat: add POSIX compliant Serial export to root

# Summary

Add an import‐time OS check that raises an ImportError on Windows and imports SerialCommonInterface as Serial on POSIX systems.

# Description

This change centralises platform compatibility in the package’s top-level module by checking `os.name` as soon as the module is imported. 

Under Windows (`"nt"`) OS, it immediately raises an `ImportError` to prevent any further usage and informs users that support isn’t available (yet). 

Under POSIX (`"posix"`), it pulls in the existing `SerialCommonInterface` from the `common` module and exposes it as `Serial` for downstream code. 

This fail-fast approach makes it obvious which platforms are supported, stops accidental imports on unsupported systems, and creates a single extension point: when a Windows implementation is ready, you can replace the `ImportError` with a conditional import of, say, `SerialWindowsInterface`, without changing any public APIs.  

This work precludes having full support for Windows systems.

# API Example Usage (*optional)

On POSIX-compliant systems, e.g., Linux:

```python
from samps import Serial

serial.open()

print(["Serial Port Is Open?", "Yes" if serial.is_open() else "No"])

line = serial.readline()

print(line.decode("utf-8").strip())

serial.close()

print(["Serial Port Closed"])
```

# Testing

- [X] I added or updated tests to cover my changes.

# Checklist

- [X] My commit messages follow the Conventional Commits specification.
- [X] I have updated documentation (if needed).
- [X] I have performed a self-review of my own code.
- [X] I have checked for type annotations and linting issues.

# Breaking Changes?

- [ ] Includes Breaking API Changes?

---

*Thank you for improving samps!*  