### PR TITLE
feat: add Port typed dict to ports in samps module

### DIFF
--- a/src/samps/ports.py
+++ b/src/samps/ports.py
@@ -1,0 +1,22 @@
+# **************************************************************************************
+
+# @package        samps
+# @license        MIT License Copyright (c) 2025 Michael J. Roberts
+
+# **************************************************************************************
+
+from typing import Optional, TypedDict
+
+# **************************************************************************************
+
+
+class Port(TypedDict):
+    # The name of the device entry, e.g., 'ttyUSB0':
+    name: str
+    # The vendor ID of the device, if available:
+    vid: Optional[int]
+    # The product ID of the device, if available:
+    pid: Optional[int]
+
+
+# **************************************************************************************


### PR DESCRIPTION
feat: add Port typed dict to ports in samps module

<!--
Thank you for your contribution! Please fill out the sections below to help us review your PR.
-->

# Linked Issues

N/A

# Summary

This PR introduces the concept of a `Port`, representing a name, a vendor identifier and a product identifier.

# Description

The `Port` concept will allow users to search for serial devices, giving them a name, e.g., "/dev/ttyAM0" which corresponds to a vendor identifier (vid) and a product identifier (pid), such that different devices can be correlated to their serial port. 

# Testing

- [ ] I added or updated tests to cover my changes.

# Checklist

- [x] My commit messages follow the Conventional Commits specification.
- [x] I have updated documentation (if needed).
- [x] I have performed a self-review of my own code.
- [x] I have checked for type annotations and linting issues.

# Breaking Changes?

- [ ] Includes Breaking API Changes?

---

*Thank you for improving samps!*  