### PR TITLE
feat: add ask method to SerialCommonInterface to common in samps module

### DIFF
--- a/src/samps/common.py
+++ b/src/samps/common.py
@@ -592,6 +592,21 @@ class SerialCommonInterface:
 
         return written
 
+    def ask(self, data: bytes, eol: bytes = b"\n", maximum_bytes: int = -1) -> bytes:
+        """
+        Ask the device by writing `data` and reading a response line ending with `eol`.
+
+        Args:
+            data: Bytes to write as the query.
+            eol: End-of-line marker for the response (default: b'\n').
+            maximum_bytes: Maximum bytes to read in response (-1 for no limit).
+
+        Returns:
+            The response bytes read from the device.
+        """
+        self.write(data)
+        return self.readline(eol, maximum_bytes)
+
     def flush(self) -> None:
         """
         Block until all written output has been transmitted to the serial device.

--- a/test/test_common.py
+++ b/test/test_common.py
@@ -115,6 +115,20 @@ class TestSerialCommonInterface(unittest.TestCase):
         read_back = self.serial.read(len(data))
         self.assertEqual(read_back, data)
 
+    def test_ask_through_pty(self) -> None:
+        """
+        Test the ask method for write followed by read:
+        """
+        query = b"hello-world\n"
+        reply = b"echo: hello-world\n"
+
+        os.write(self.master_file_descriptor, reply)
+
+        response = self.serial.ask(query)
+        self.assertEqual(response, reply)
+        written_back = os.read(self.master_file_descriptor, len(query))
+        self.assertEqual(written_back, query)
+
     def test_read_zero_length(self) -> None:
         """
         Test that reading zero bytes returns an empty bytes object:


### PR DESCRIPTION
feat: add ask method to SerialCommonInterface to common in samps module

<!--
Thank you for your contribution! Please fill out the sections below to help us review your PR.
-->

# Linked Issues

<!--
List any related issues by number, e.g. Closes #1, Relates to #2, etc.
-->

N/A

# Summary

<!--
Provide a brief, imperative description of your changes.
-->

Add `ask()` to `SerialCommonInterface` as a small convenience API that writes a request and then reads a line-terminated response using the existing timeout and error semantics.

# Description

<!--
Explain what you’ve changed, why, and any context needed to understand the impact.
-->

This PR introduces a convenience `ask()` method on `SerialCommonInterface` that combines a write request with a line-terminated read response using the existing timeout and error behaviour. It allows callers to send a command and immediately read the corresponding reply without manually invoking `write()` and `readline()`. The rationale for adding this method is that many serial protocols follow a simple request/response pattern, and providing a first-class helper reduces boilerplate while retaining full control over terminators and maximum read length.

# API Example Usage (*optional)

<!--
If your change adds or modifies public APIs, show example usage here:
-->

```python
from samps import Serial

# Basic usage (device expects LF-terminated command)
with Serial("/dev/ttyUSB0", baudrate=9600) as serial:
    response = serial.ask(b"STATUS?\n")  # write -> read line
    print(response)
```

# Testing

- [X] I added or updated tests to cover my changes.

# Checklist

- [X] My commit messages follow the Conventional Commits specification.
- [X] I have updated documentation (if needed).
- [X] I have performed a self-review of my own code.
- [X] I have checked for type annotations and linting issues.

# Breaking Changes?

- [ ] Includes Breaking API Changes?

Pure additive change. No behavioral changes to existing methods.

---

*Thank you for improving samps!*  