### PR TITLE
feat: add get_cyclic_redundancy_checksum to crc in samps module

### DIFF
--- a/src/samps/__init__.py
+++ b/src/samps/__init__.py
@@ -23,6 +23,7 @@ from .common import (
     SerialCommonInterfaceParameters,
     SerialInitialisationParameters,
 )
+from .crc import get_cyclic_redundancy_checksum
 from .errors import (
     SerialReadError,
     SerialTimeoutError,
@@ -58,6 +59,7 @@ __all__: list[str] = [
     "SerialReadError",
     "SerialTimeoutError",
     "SerialWriteError",
+    "get_cyclic_redundancy_checksum",
     "hex_to_int",
     "int_to_hex",
 ]

--- a/src/samps/crc.py
+++ b/src/samps/crc.py
@@ -1,0 +1,93 @@
+# **************************************************************************************
+
+# @package        samps
+# @license        MIT License Copyright (c) 2025 Michael J. Roberts
+
+# **************************************************************************************
+
+from typing import Dict, Literal, TypedDict
+
+# **************************************************************************************
+
+
+class CRCSpecification(TypedDict):
+    # The initial checksum register value:
+    start: int
+    # The polynomial to use for the CRC calculation:
+    polynomial: int
+
+
+# **************************************************************************************
+
+CRC_SPEC_LOOKUP: Dict[Literal[8, 16, 32], CRCSpecification] = {
+    # CRC-8-ATM:
+    8: {
+        "start": 0x00,
+        "polynomial": 0x07,
+    },
+    # CRC-16-Modbus (reflected):
+    16: {
+        "start": 0xFFFF,
+        "polynomial": 0xA001,
+    },
+    # CRC-32-IEEE (reflected):
+    32: {
+        "start": 0xFFFFFFFF,
+        "polynomial": 0xEDB88320,
+    },
+}
+
+# **************************************************************************************
+
+
+def get_cyclic_redundancy_checksum(
+    data: bytes,
+    bits: Literal[8, 16, 32] = 16,
+) -> int:
+    """
+    Compute the cyclic redundancy checksum (CRC) of the given data.
+
+    Args:
+        data: The input data as bytes.
+        bits: The CRC bit size (8, 16, or 32). Default is 16.
+
+    Returns:
+        The computed CRC as an integer.
+    """
+    # Ensure only the supported bit sizes are used:
+    if bits not in CRC_SPEC_LOOKUP:
+        raise ValueError(f"Unsupported CRC bit size: {bits}")
+
+    specification = CRC_SPEC_LOOKUP[bits]
+
+    crc = specification["start"]
+
+    polynomial = specification["polynomial"]
+
+    for byte in data:
+        # Combine the next byte with the current CRC register:
+        crc ^= byte
+
+        # Process each bit of the current byte:
+        for _ in range(8):
+            # CRC-8 (MSB-first): shift left and test bit 7 (0x80):
+            if bits == 8:
+                crc = (
+                    ((crc << 1) ^ polynomial) & 0xFF
+                    if crc & 0x80
+                    else (crc << 1) & 0xFF
+                )
+            # CRC-16 and CRC-32 (reflected): shift right and test bit 0:
+            else:
+                crc = (crc >> 1) ^ polynomial if crc & 1 else crc >> 1
+
+    mask = (1 << bits) - 1
+
+    # CRC-32 final XOR value:
+    if bits == 32:
+        crc = (~crc) & 0xFFFFFFFF
+
+    return crc & mask
+
+
+# **************************************************************************************

--- a/test/test_crc.py
+++ b/test/test_crc.py
@@ -1,0 +1,71 @@
+# **************************************************************************************
+
+# @package        samps
+# @license        MIT License Copyright (c) 2025 Michael J. Roberts
+
+# **************************************************************************************
+
+import unittest
+from struct import pack
+from typing import Any
+
+from samps.crc import get_cyclic_redundancy_checksum
+
+# **************************************************************************************
+
+
+class TestCyclicRedundancyChecksum(unittest.TestCase):
+    def test_crc8(self) -> None:
+        data: bytes = b"123456789"
+        crc = get_cyclic_redundancy_checksum(data, 8)
+        self.assertEqual(crc, 0xF4)
+
+    def test_crc16(self) -> None:
+        data: bytes = b"123456789"
+        crc = get_cyclic_redundancy_checksum(data, 16)
+        self.assertEqual(crc, 0x4B37)
+
+    def test_crc32(self) -> None:
+        data: bytes = b"123456789"
+        crc = get_cyclic_redundancy_checksum(data, 32)
+        self.assertEqual(crc, 0xCBF43926)
+
+    def test_bit_masking(self) -> None:
+        data: bytes = bytes(range(256))
+        crc = get_cyclic_redundancy_checksum(data, 8)
+        self.assertTrue(0 <= crc <= 0xFF)
+
+        crc = get_cyclic_redundancy_checksum(data, 16)
+        self.assertTrue(0 <= crc <= 0xFFFF)
+
+        crc = get_cyclic_redundancy_checksum(data, 32)
+        self.assertTrue(0 <= crc <= 0xFFFFFFFF)
+
+    def test_invalid_bits(self) -> None:
+        bits: Any = 12
+
+        with self.assertRaises(ValueError):
+            _ = get_cyclic_redundancy_checksum(b"abc", bits)
+
+    def test_empty_data(self) -> None:
+        crc = get_cyclic_redundancy_checksum(b"", 8)
+        self.assertEqual(crc, 0x00)
+
+        crc = get_cyclic_redundancy_checksum(b"", 16)
+        self.assertEqual(crc, 0xFFFF)
+
+        crc = get_cyclic_redundancy_checksum(b"", 32)
+        self.assertEqual(crc, 0x00000000)
+
+    def test_number_of_bytes(self) -> None:
+        crc = get_cyclic_redundancy_checksum(b"A", 8)
+        bytes = pack("<H", crc)
+        self.assertEqual(len(crc.to_bytes(2, "little")), len(bytes))
+
+
+# **************************************************************************************
+
+if __name__ == "__main__":
+    unittest.main()
+
+# **************************************************************************************


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below to help us review your PR.
-->

# Linked Issues

<!--
List any related issues by number, e.g. Closes #1, Relates to #2, etc.
-->

N/A

# Summary

This PR adds the utility for calculating cyclic redundancy checksums (CRCs).

<!--
Provide a brief, imperative description of your changes.
-->

# Description

<!--
Explain what you’ve changed, why, and any context needed to understand the impact.
-->

# API Example Usage (*optional)

<!--
If your change adds or modifies public APIs, show example usage here:
-->

```python
from samps import get_cyclic_redundancy_checksum

data = b""

crc = get_cyclic_redundancy_checksum(data=data, bits=16)
```

# Testing

- [X] I added or updated tests to cover my changes.

# Checklist

- [X] My commit messages follow the Conventional Commits specification.
- [ ] I have updated documentation (if needed).
- [X] I have performed a self-review of my own code.
- [X] I have checked for type annotations and linting issues.

# Breaking Changes?

- [ ] Includes Breaking API Changes?

---

*Thank you for improving samps!*  