### PR TITLE
feat: add XIMCSerialInterface to ximc in samps module

### DIFF
--- a/src/samps/__init__.py
+++ b/src/samps/__init__.py
@@ -28,8 +28,12 @@ from .errors import (
     SerialReadError,
     SerialTimeoutError,
     SerialWriteError,
+    XIMCCommandNotRecognisedError,
+    XIMCInvalidCRCError,
+    XIMCValueOutOfRangeError,
 )
 from .utilities import hex_to_int, int_to_hex
+from .ximc import XIMCSerialInterface
 
 # If the operating system is POSIX compliant, import the Serial class from the common module:
 if name == "posix":
@@ -59,6 +63,10 @@ __all__: list[str] = [
     "SerialReadError",
     "SerialTimeoutError",
     "SerialWriteError",
+    "XIMCSerialInterface",
+    "XIMCCommandNotRecognisedError",
+    "XIMCInvalidCRCError",
+    "XIMCValueOutOfRangeError",
     "get_cyclic_redundancy_checksum",
     "hex_to_int",
     "int_to_hex",

--- a/src/samps/errors.py
+++ b/src/samps/errors.py
@@ -40,3 +40,39 @@ class SerialWriteError(Exception):
 
 
 # **************************************************************************************
+
+
+class XIMCCommandNotRecognisedError(Exception):
+    """
+    Exception class for XIMC command not recognised errors.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+# **************************************************************************************
+
+
+class XIMCInvalidCRCError(Exception):
+    """
+    Exception class for XIMC invalid CRC errors.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+# **************************************************************************************
+
+
+class XIMCValueOutOfRangeError(Exception):
+    """
+    Exception class for XIMC value out of range errors.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+# **************************************************************************************

--- a/src/samps/ximc.py
+++ b/src/samps/ximc.py
@@ -1,0 +1,126 @@
+# **************************************************************************************
+
+# @package        samps
+# @license        MIT License Copyright (c) 2025 Michael J. Roberts
+
+# **************************************************************************************
+
+from struct import pack, unpack_from
+from typing import Final
+
+from .common import SerialCommonInterface
+from .crc import get_cyclic_redundancy_checksum
+from .errors import (
+    SerialWriteError,
+    XIMCCommandNotRecognisedError,
+    XIMCInvalidCRCError,
+    XIMCValueOutOfRangeError,
+)
+
+# **************************************************************************************
+
+# First 4 bytes of a reply are the echoed command:
+XIMC_ECHO_SIZE: Final[int] = 4
+
+# **************************************************************************************
+
+# CRC16 (little-endian) appended after payload
+XIMC_CRC_SIZE: Final[int] = 2
+
+# **************************************************************************************
+
+
+class XIMCSerialInterface(SerialCommonInterface):
+    def write(self, data: bytes) -> int:
+        # Expect data = command(4) + payload; CRC covers payload only:
+        if len(data) < XIMC_ECHO_SIZE:
+            raise SerialWriteError("Data is too short to contain command")
+
+        # Compute CRC16 (Modbus-style) and append it (little-endian):
+        payload = data[XIMC_ECHO_SIZE:]
+
+        checksum = get_cyclic_redundancy_checksum(payload, 16)
+
+        return super().write(data + pack("<H", checksum))
+
+    def read(self, size: int = 1) -> bytes:
+        # Read enough bytes to ensure we get the expected number of non-zero bytes
+        # after stripping leading zeros.
+        expected_size = size + XIMC_CRC_SIZE
+
+        # Buffer to hold incoming data
+        buffer = b""
+
+        # Read in chunks until we have enough non-zero bytes after stripping leading zeros.
+        while True:
+            buffer += super().read(
+                expected_size - len(buffer) if expected_size - len(buffer) > 0 else 1
+            )
+
+            # Remove any leading zero bytes used for zero-byte resynchronisation:
+            i = 0
+
+            n = len(buffer)
+
+            while i < n and buffer[i] == 0x00:
+                i += 1
+
+            frame = buffer[i:]
+
+            # If we have enough non-zero bytes, break:
+            if len(frame) >= expected_size:
+                break
+
+            # Otherwise, continue reading...
+
+        if len(frame) < XIMC_CRC_SIZE:
+            raise ValueError("Received data is too short to contain CRC")
+
+        # Separate the data (command and any payload) and CRC:
+        data = frame[:-XIMC_CRC_SIZE]
+
+        crc = unpack_from("<H", frame[-XIMC_CRC_SIZE:])[0]
+
+        checksum = get_cyclic_redundancy_checksum(data[4:], 16)
+
+        # Ensure that the expected checksum matches the received CRC:
+        if crc != checksum:
+            raise ValueError(
+                f"CRC mismatch: expected {hex(checksum)}, got {hex(crc)}",
+            )
+
+        # Extract the echoed command and any payload from the data:
+        command, payload = data[:XIMC_ECHO_SIZE], data[XIMC_ECHO_SIZE:]
+
+        if command == b"errc":
+            raise XIMCCommandNotRecognisedError(
+                "Controller returned ERRC (command not recognised)",
+            )
+
+        if command == b"errd":
+            raise XIMCInvalidCRCError(
+                "Controller returned ERRD (invalid data CRC received by controller)",
+            )
+
+        if command == b"errv":
+            raise XIMCValueOutOfRangeError(
+                "Controller returned ERRV (value out of range)",
+            )
+
+        # Strip off echoed command at start:
+        if len(data) < XIMC_ECHO_SIZE:
+            raise ValueError(
+                "Received data is too short to contain echoed command",
+            )
+
+        return payload
+
+    def ask(self, data: bytes, eol: bytes = b"\n", maximum_bytes: int = -1) -> bytes:
+        # Perform a write/read transaction, framing handled automatically:
+        self.write(data)
+        # EOL handling is ignored; XIMC uses fixed-size replies:
+        data = self.read(maximum_bytes if maximum_bytes > 0 else 64)
+        return data
+
+
+# **************************************************************************************

--- a/test/test_ximc.py
+++ b/test/test_ximc.py
@@ -1,0 +1,431 @@
+# **************************************************************************************
+
+# @package        samps
+# @license        MIT License Copyright (c) 2025 Michael J. Roberts
+
+# **************************************************************************************
+
+import os
+import termios
+import time
+import unittest
+import unittest.mock
+from errno import EINVAL
+from struct import pack
+from typing import cast
+
+from samps import (
+    BAUDRATES,
+    BaudrateType,
+    SerialCommonInterfaceParameters,
+    SerialReadError,
+    SerialWriteError,
+    XIMCSerialInterface,
+    get_cyclic_redundancy_checksum,
+)
+
+# **************************************************************************************
+
+
+class TestXIMCSerialInterface(unittest.TestCase):
+    """
+    Unit tests for XIMCSerialInterface using a pseudo-TTY device:
+    """
+
+    master_file_descriptor: int
+    slave_file_descriptor: int
+    slave_device_name: str
+    serial: XIMCSerialInterface
+
+    def setUp(self) -> None:
+        """
+        Create a pseudo-TTY pair and open the serial interface on the slave end:
+        """
+        self.master_file_descriptor, self.slave_file_descriptor = os.openpty()
+        self.slave_device_name = os.ttyname(self.slave_file_descriptor)
+
+        params = SerialCommonInterfaceParameters(
+            {
+                "bytesize": 8,
+                "parity": "N",
+                "stopbits": 2,
+                "timeout": 0.4,
+                "xonxoff": False,
+                "rtscts": False,
+            }
+        )
+
+        self.serial = XIMCSerialInterface(
+            port=self.slave_device_name,
+            baudrate=115200,
+            params=params,
+        )
+        self.serial.open()
+
+    def tearDown(self) -> None:
+        """
+        Close the serial interface and underlying file descriptors:
+        """
+        self.serial.close()
+        os.close(self.master_file_descriptor)
+        os.close(self.slave_file_descriptor)
+
+    def test_context_manager_opens_and_closes(self) -> None:
+        """
+        Test that the context manager opens on enter and closes on exit:
+        """
+        with XIMCSerialInterface(
+            port=self.slave_device_name,
+            baudrate=115200,
+            params={
+                "bytesize": 8,
+                "parity": "N",
+                "stopbits": 2,
+                "timeout": 0.4,
+                "xonxoff": False,
+                "rtscts": False,
+            },
+        ) as serial_context:
+            self.assertTrue(serial_context.is_open())
+        self.assertFalse(serial_context.is_open())
+
+    def test_is_open_and_is_closed(self) -> None:
+        """
+        Test the is_open and is_closed methods:
+        """
+        self.assertTrue(self.serial.is_open())
+        self.assertFalse(self.serial.is_closed())
+        self.serial.close()
+        self.assertFalse(self.serial.is_open())
+        self.assertTrue(self.serial.is_closed())
+
+    def test_repr_contains_port_and_baudrate(self) -> None:
+        """
+        Test that __repr__ includes port and baudrate information:
+        """
+        representation = repr(self.serial)
+        self.assertIn(self.slave_device_name, representation)
+        self.assertIn("115200", representation)
+
+    def test_write_and_read_through_pty(self) -> None:
+        """
+        Test writing to the slave is readable from the master and vice versa:
+        """
+        data = b"hello-world"
+        number_written = self.serial.write(data)
+        self.assertEqual(number_written, len(data) + 2)
+
+        received = os.read(self.master_file_descriptor, len(data) + 2)
+        self.assertEqual(received[:-2], data)
+
+        payload = data[4:]
+        self.assertEqual(
+            int.from_bytes(received[-2:], "little"),
+            get_cyclic_redundancy_checksum(payload, 16),
+        )
+
+        echo = data[:4]
+        reply_payload = payload
+        reply_crc = get_cyclic_redundancy_checksum(reply_payload, 16)
+        os.write(
+            self.master_file_descriptor,
+            echo
+            + reply_payload
+            + reply_crc.to_bytes(
+                2,
+                "little",
+            ),
+        )
+
+        read_back = self.serial.read(len(echo) + len(reply_payload))
+        self.assertEqual(read_back, reply_payload)
+
+    def test_ask_through_pty(self) -> None:
+        """
+        Test the ask method for write followed by read:
+        """
+        query = b"hello-world\n"
+        reply = b"echo: hello-world\n"
+
+        echo = reply[:4]
+        reply_payload = reply[4:]
+        reply_crc = get_cyclic_redundancy_checksum(reply_payload, 16)
+        os.write(
+            self.master_file_descriptor,
+            echo
+            + reply_payload
+            + reply_crc.to_bytes(
+                2,
+                "little",
+            ),
+        )
+
+        response = self.serial.ask(query, maximum_bytes=len(echo) + len(reply_payload))
+        self.assertEqual(response, reply_payload)
+
+        written_back = os.read(self.master_file_descriptor, len(query) + 2)
+        self.assertEqual(written_back[:-2], query)
+        written_payload = query[4:]
+        self.assertEqual(
+            int.from_bytes(
+                written_back[-2:],
+                "little",
+            ),
+            get_cyclic_redundancy_checksum(written_payload, 16),
+        )
+
+    def test_read_zero_length(self) -> None:
+        """
+        Test that reading zero bytes raises an error:
+        """
+        with self.assertRaises(SerialReadError):
+            self.serial.read(0)
+
+    def test_write_zero_length(self) -> None:
+        """
+        Test that writing zero bytes raises:
+        """
+        with self.assertRaises(SerialWriteError):
+            self.serial.write(b"")
+
+    def test_partial_write_retries(self) -> None:
+        """
+        Test that write retries on partial writes until all bytes are written:
+        """
+        # Used to simulate a partial write condition on the first call to fake_write:
+        original_write = os.write
+        calls: list[int] = []
+
+        def fake_write(fd: int, buf: bytes) -> int:
+            if not calls:
+                calls.append(1)
+                return original_write(fd, buf[: len(buf) // 2])
+            return original_write(fd, buf)
+
+        with unittest.mock.patch("os.write", new=fake_write):
+            data = b"ABCDEFGH"
+            number_written = self.serial.write(data)
+            self.assertEqual(number_written, len(data) + 2)
+
+            received = b""
+            target = len(data) + 2
+            while len(received) < target:
+                received += os.read(self.master_file_descriptor, target - len(received))
+
+            self.assertEqual(received[:-2], data)
+            payload = data[4:]
+            self.assertEqual(
+                int.from_bytes(received[-2:], "little"),
+                get_cyclic_redundancy_checksum(payload, 16),
+            )
+
+    def test_read_timeout_raises(self) -> None:
+        """
+        Test that read raises a SerialReadError after the timeout expires:
+        """
+        short_serial = XIMCSerialInterface(
+            port=self.slave_device_name,
+            baudrate=9600,
+            params={
+                "bytesize": 8,
+                "parity": "N",
+                "stopbits": 1,
+                "timeout": 0.1,
+                "xonxoff": False,
+                "rtscts": False,
+            },
+        )
+        short_serial.open()
+        start_time = time.time()
+        with self.assertRaises(SerialReadError):
+            short_serial.read(1)
+        self.assertGreaterEqual(time.time() - start_time, 0.1)
+        short_serial.close()
+
+    def test_constructor_without_params_uses_defaults(self) -> None:
+        """
+        Test that omitting params falls back to the default parameters:
+        """
+        serial2 = XIMCSerialInterface(
+            port=self.slave_device_name,
+            baudrate=19200,
+        )
+        serial2.open()
+        self.assertTrue(serial2.is_open())
+        # Default bytesize and parity come from default_serial_parameters
+        self.assertEqual(serial2.bytesize, 8)
+        self.assertEqual(serial2.parity, "N")
+        serial2.close()
+
+    def test_read_nontransient_error_raises(self) -> None:
+        """
+        Test that a non-transient OSError in read is wrapped in SerialReadError:
+        """
+        with unittest.mock.patch("os.read", side_effect=OSError(EINVAL, "bad")):
+            with self.assertRaises(SerialReadError):
+                self.serial.read(1)
+
+    def test_write_nontransient_error_raises(self) -> None:
+        """
+        Test that a non-transient OSError in write is wrapped in SerialWriteError:
+        """
+        with unittest.mock.patch("os.write", side_effect=OSError(EINVAL, "bad")):
+            with self.assertRaises(SerialWriteError):
+                self.serial.write(b"x")
+
+    def test_flush_before_and_after_open(self) -> None:
+        """
+        Test that flush works when open and raises when closed:
+        """
+        self.serial.flush()
+        self.serial.close()
+        with self.assertRaises(RuntimeError):
+            self.serial.flush()
+
+    def test_property_setters_apply_settings(self) -> None:
+        """
+        Test that setting bytesize and parity updates internal state:
+        """
+        with unittest.mock.patch.object(
+            self.serial, "_configure_tty_settings", lambda attrs: None
+        ):
+            for size in (5, 6, 7, 8):
+                self.serial.set_bytesize(size)
+                self.assertEqual(self.serial.bytesize, size)
+            for parity_value in ("N", "E", "O"):
+                self.serial.set_parity(parity_value)
+                self.assertEqual(self.serial.parity, parity_value)
+
+    def test_baudrate_setter(self) -> None:
+        """
+        Test that setting baudrate updates internal state without error:
+        """
+        for raw in BAUDRATES:
+            baudrate_value: BaudrateType = cast(BaudrateType, raw)
+            self.serial.set_baudrate(baudrate_value)
+            self.assertEqual(self.serial.baudrate, baudrate_value)
+
+    def test_set_port_updates_property(self) -> None:
+        """
+        Test that set_port changes the port property and reapplies settings:
+        """
+        master, slave = os.openpty()
+        name = os.ttyname(slave)
+        try:
+            self.serial.set_port(name)
+            self.assertEqual(self.serial.port, name)
+        finally:
+            os.close(master)
+            os.close(slave)
+
+    def test_get_termios_attributes_structure(self) -> None:
+        """
+        Test that _get_termios_attributes returns a correctly structured dict:
+        """
+        termios_attributes = self.serial._get_termios_attributes()
+        self.assertIsInstance(termios_attributes, dict)
+        expected_keys = {
+            "iflag",
+            "oflag",
+            "cflag",
+            "lflag",
+            "ispeed",
+            "ospeed",
+            "control_chars",
+        }
+        self.assertEqual(set(termios_attributes.keys()), expected_keys)
+        self.assertIsInstance(termios_attributes["control_chars"], list)
+        self.assertGreaterEqual(
+            len(termios_attributes["control_chars"]), termios.VTIME + 1
+        )
+
+    def test_home_roundtrip(self) -> None:
+        command = "home".encode("ascii")
+        payload = b""
+
+        number_written = self.serial.write(command + payload)
+        self.assertEqual(number_written, len(command) + len(payload) + 2)
+
+        written = os.read(self.master_file_descriptor, number_written)
+        self.assertEqual(written[:-2], command + payload)
+        self.assertEqual(
+            int.from_bytes(written[-2:], "little"),
+            get_cyclic_redundancy_checksum(payload, 16),
+        )
+
+        crc = get_cyclic_redundancy_checksum(payload, 16)
+        os.write(
+            self.master_file_descriptor, command + payload + crc.to_bytes(2, "little")
+        )
+
+        received = self.serial.read(len(command) + len(payload))
+        self.assertEqual(received, payload)
+
+    def test_gpos_roundtrip(self) -> None:
+        command = "gpos".encode("ascii")
+        payload = b""
+
+        number_written = self.serial.write(command + payload)
+        self.assertEqual(number_written, len(command) + 2)
+        written = os.read(self.master_file_descriptor, number_written)
+
+        self.assertEqual(written[:-2], command + payload)
+        self.assertEqual(
+            int.from_bytes(
+                written[-2:],
+                "little",
+            ),
+            get_cyclic_redundancy_checksum(payload, 16),
+        )
+
+        crc = get_cyclic_redundancy_checksum(payload, 16)
+        os.write(
+            self.master_file_descriptor,
+            command
+            + payload
+            + crc.to_bytes(
+                2,
+                "little",
+            ),
+        )
+
+        received = self.serial.read(len(command) + len(payload))
+        self.assertEqual(received, payload)
+
+    def test_movr_roundtrip(self) -> None:
+        command = "movr".encode("ascii")
+        # DeltaPosition=200 (int32 LE), uDPos=0 (uint16 LE), Reserved=0 (uint32 LE, twice):
+        payload = pack("<iHII", 200, 0, 0, 0)
+
+        number_written = self.serial.write(command + payload)
+        self.assertEqual(number_written, len(command) + len(payload) + 2)
+        written = os.read(self.master_file_descriptor, number_written)
+
+        self.assertEqual(written[:-2], command + payload)
+        self.assertEqual(
+            int.from_bytes(written[-2:], "little"),
+            get_cyclic_redundancy_checksum(payload, 16),
+        )
+
+        crc = get_cyclic_redundancy_checksum(payload, 16)
+        os.write(
+            self.master_file_descriptor, command + payload + crc.to_bytes(2, "little")
+        )
+
+        received = self.serial.read(len(command) + len(payload))
+        self.assertEqual(received, payload)
+
+    def test_close_idempotent(self) -> None:
+        """
+        Test that calling close multiple times does not raise:
+        """
+        self.serial.close()
+        self.serial.close()
+
+
+# **************************************************************************************
+
+if __name__ == "__main__":
+    unittest.main()
+
+# **************************************************************************************


### PR DESCRIPTION
feat: add XIMCSerialInterface to ximc in samps module

<!--
Thank you for your contribution! Please fill out the sections below to help us review your PR.
-->

# Linked Issues

<!--
List any related issues by number, e.g. Closes #1, Relates to #2, etc.
-->

# Summary

<!--
Provide a brief, imperative description of your changes.
-->

This PR introduces the XIMC implementation on top of the SerialDeviceInterface as per the [XIMC protocol](https://doc.xisupport.com/en/8smc5-usb/8SMCn-USB/Programming/Communication_protocol_specification.html#protocol-description).

# Description

<!--
Explain what you’ve changed, why, and any context needed to understand the impact.
-->

This update introduces a new `XIMCSerialInterface` class that extends the `SerialCommonInterface` to fully support communication with xIMC-compatible motor controllers. 

The interface implements protocol-compliant framing and validation, including CRC16 checksums calculated over the payload (excluding the 4-byte command identifier), automatic echo command stripping, and handling of controller error responses (`b"errc"`, `b"errd"` and `b"errv"` responses). It also includes support for zero-byte resynchronisation to recover communication after desynchronisation events. 

A comprehensive unit test suite has been added to verify roundtrip communication for common commands (e.g., home, gpos, movr), CRC integrity, error handling, and serial I/O behavior across pseudo-TTY devices to match against the base `SerialCommonInterface`. It is fully backwards compatible with `SerialCommonInterface` and will be kept as such.

# API Example Usage

<!--
If your change adds or modifies public APIs, show example usage here:
-->

```python
from samps import (
    XIMCSerialInterface, 
    SerialCommonInterfaceParameters,
)

params = SerialCommonInterfaceParameters(
    {
        "bytesize": 8,
        "parity": "N",
        "stopbits": 2,
        "timeout": 0.4,
        "xonxoff": False,
        "rtscts": False,
    }
)

serial = XIMCSerialInterface(
    port=self.slave_device_name,
    baudrate=115200,
    params=params,
)

serial.open()
```

An example of the move command:

```python
command = b"move"

# Payload layout: <iH6x e.g., int32 position, uint16 uPosition, 6 reserved zero bytes:
payload = pack("<iH6x", 10000, 0)

# Send command+payload; CRC(16) is auto-added; reply is just echo, so returned payload is b""""
response = serial.ask(
    command + payload, maximum_bytes=4
)
```

# Testing

- [X] I added or updated tests to cover my changes.

# Checklist

- [X] My commit messages follow the Conventional Commits specification.
- [ ] I have updated documentation (if needed).
- [X] I have performed a self-review of my own code.
- [X] I have checked for type annotations and linting issues.

# Breaking Changes?

- [ ] Includes Breaking API Changes?

---

*Thank you for improving samps!*  