### PR TITLE
refactor: removed redundant SerialInitialisationParameters in samps module

### DIFF
--- a/src/samps/__init__.py
+++ b/src/samps/__init__.py
@@ -21,7 +21,6 @@ from .baudrate import BAUDRATE_LOOKUP_FLAGS, BAUDRATES, BaudrateType
 from .common import (
     SerialCommonInterface,
     SerialCommonInterfaceParameters,
-    SerialInitialisationParameters,
 )
 from .crc import get_cyclic_redundancy_checksum
 from .errors import (
@@ -55,7 +54,6 @@ __all__: list[str] = [
     "SerialAsyncCommonInterface",
     "SerialCommonInterface",
     "SerialCommonInterfaceParameters",
-    "SerialInitialisationParameters",
     "SerialReadError",
     "SerialTimeoutError",
     "SerialWriteError",

--- a/src/samps/common.py
+++ b/src/samps/common.py
@@ -89,18 +89,6 @@ class SerialCommonInterfaceParameters(TypedDict):
 
 # **************************************************************************************
 
-
-class SerialInitialisationParameters(TypedDict):
-    # The device port to connect to (e.g. '/dev/ttyUSB0'):
-    port: str
-    # The baud rate for the serial connection (in symbols per second):
-    baudrate: BaudrateType
-    # The timeout for the serial connection (in seconds) or None for blocking mode:
-    timeout: Optional[float]
-
-
-# **************************************************************************************
-
 default_serial_parameters: SerialCommonInterfaceParameters = (
     SerialCommonInterfaceParameters(
         {


### PR DESCRIPTION
refactor: removed redundant SerialInitialisationParameters in samps module