### PR TITLE
feat: add clear_input_buffer method to SerialCommonInterface in common module in samps

### DIFF
--- a/src/samps/common.py
+++ b/src/samps/common.py
@@ -583,6 +583,12 @@ class SerialCommonInterface:
         # transmitted and drained:
         tcdrain(self._fd)
 
+    def clear_input_buffer(self) -> None:
+        """
+        Discard data in the input buffer (flush the input buffer).
+        """
+        self.abort_in()
+
     def abort_in(self) -> None:
         """
         Discard data in the input buffer (flush the input buffer).


### PR DESCRIPTION
feat: add clear_input_buffer method to SerialCommonInterface in common module in samps

<!--
Thank you for your contribution! Please fill out the sections below to help us review your PR.
-->

# Linked Issues

<!--
List any related issues by number, e.g. Closes #1, Relates to #2, etc.
-->

N/A

# Summary

<!--
Provide a brief, imperative description of your changes.
-->

This PR introduces an alias method `clear_input_buffer()` that is more human intuitive than `abort_in()`.

# Description

<!--
Explain what you’ve changed, why, and any context needed to understand the impact.
-->

Identical to pyserial's usage of the `reset_input_buffer()`, we expose a `clear_input_buffer()` on the Serial interface class.

# API Example Usage (*optional)

<!--
If your change adds or modifies public APIs, show example usage here:
-->

```python
from samps import (
    SerialCommonInterface, 
    SerialCommonInterfaceParameters,
)

params = SerialCommonInterfaceParameters(
    {
        "bytesize": 8,
        "parity": "N",
        "stopbits": 2,
        "timeout": 0.4,
        "xonxoff": False,
        "rtscts": False,
    }
)

serial = SerialCommonInterface(
    port=self.slave_device_name,
    baudrate=115200,
    params=params,
)

serial.clear_input_buffer()
```

# Testing

- [ ] I added or updated tests to cover my changes.

# Checklist

- [X] My commit messages follow the Conventional Commits specification.
- [X] I have updated documentation (if needed).
- [X] I have performed a self-review of my own code.
- [X] I have checked for type annotations and linting issues.

# Breaking Changes?

- [ ] Includes Breaking API Changes?

---

*Thank you for improving samps!*  